### PR TITLE
Remove the graphql-java dependency to avoid a NoSuchMethodError due t…

### DIFF
--- a/buildSrc/src/main/kotlin/multimodule-config.gradle.kts
+++ b/buildSrc/src/main/kotlin/multimodule-config.gradle.kts
@@ -96,7 +96,6 @@ dependencies {
     implementation("org.eclipse.lmos:arc-ollama-client:$arcVersion")
     implementation("org.eclipse.lmos:arc-reader-html:$arcVersion")
     implementation("org.eclipse.lmos:arc-graphql-spring-boot-starter:$arcVersion")
-    implementation("com.graphql-java:graphql-java:21.5")
 
     // Kotlin Dependencies
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:$kotlinXVersion")


### PR DESCRIPTION
Remove the graphql-java dependency to avoid a NoSuchMethodError due to a version conflict.

fixes  #31