### PR TITLE
Add missing snapshot dependencies to the generated docker images

### DIFF
--- a/news-agent/Dockerfile
+++ b/news-agent/Dockerfile
@@ -8,12 +8,15 @@ ARG VERSION
 COPY build/libs/news-agent-$VERSION.jar /deployments/app.jar
 WORKDIR /deployments
 RUN java -Djarmode=layertools -jar app.jar extract
+# Ensure that the snapshot-dependencies folder is created even if there were no snapshot dependencies in the jar file (to avoid error when copying from that directory below)
+RUN mkdir -p snapshot-dependencies
 
 ## Stage 2 : create image
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime
 USER 185
 WORKDIR /deployments
 COPY --from=builder /deployments/dependencies/ ./
+COPY --from=builder /deployments/snapshot-dependencies/ ./
 COPY --from=builder /deployments/spring-boot-loader/ ./
 COPY --from=builder /deployments/application/ ./
 COPY config ./config

--- a/productsearch-agent/Dockerfile
+++ b/productsearch-agent/Dockerfile
@@ -8,12 +8,15 @@ ARG VERSION
 COPY build/libs/productsearch-agent-$VERSION.jar /deployments/app.jar
 WORKDIR /deployments
 RUN java -Djarmode=layertools -jar app.jar extract
+# Ensure that the snapshot-dependencies folder is created even if there were no snapshot dependencies in the jar file (to avoid error when copying from that directory below)
+RUN mkdir -p snapshot-dependencies
 
 ## Stage 2 : create image
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime
 USER 185
 WORKDIR /deployments
 COPY --from=builder /deployments/dependencies/ ./
+COPY --from=builder /deployments/snapshot-dependencies/ ./
 COPY --from=builder /deployments/spring-boot-loader/ ./
 COPY --from=builder /deployments/application/ ./
 COPY config ./config

--- a/reportgenerate-agent/Dockerfile
+++ b/reportgenerate-agent/Dockerfile
@@ -8,6 +8,8 @@ ARG VERSION
 COPY build/libs/reportgenerate-agent-$VERSION.jar /deployments/app.jar
 WORKDIR /deployments
 RUN java -Djarmode=layertools -jar app.jar extract
+# Ensure that the snapshot-dependencies folder is created even if there were no snapshot dependencies in the jar file (to avoid error when copying from that directory below)
+RUN mkdir -p snapshot-dependencies
 
 # Make the data directory for generated files
 RUN mkdir -p /deployments/data
@@ -17,6 +19,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21-runtime
 USER 185
 WORKDIR /deployments
 COPY --from=builder /deployments/dependencies/ ./
+COPY --from=builder /deployments/snapshot-dependencies/ ./
 COPY --from=builder /deployments/spring-boot-loader/ ./
 COPY --from=builder /deployments/application/ ./
 COPY config ./config

--- a/techspec-agent/Dockerfile
+++ b/techspec-agent/Dockerfile
@@ -8,12 +8,15 @@ ARG VERSION
 COPY build/libs/techspec-agent-$VERSION.jar /deployments/app.jar
 WORKDIR /deployments
 RUN java -Djarmode=layertools -jar app.jar extract
+# Ensure that the snapshot-dependencies folder is created even if there were no snapshot dependencies in the jar file (to avoid error when copying from that directory below)
+RUN mkdir -p snapshot-dependencies
 
 ## Stage 2 : create image
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime
 USER 185
 WORKDIR /deployments
 COPY --from=builder /deployments/dependencies/ ./
+COPY --from=builder /deployments/snapshot-dependencies/ ./
 COPY --from=builder /deployments/spring-boot-loader/ ./
 COPY --from=builder /deployments/application/ ./
 COPY config ./config

--- a/weather-agent/Dockerfile
+++ b/weather-agent/Dockerfile
@@ -8,12 +8,15 @@ ARG VERSION
 COPY build/libs/weather-agent-$VERSION.jar /deployments/app.jar
 WORKDIR /deployments
 RUN java -Djarmode=layertools -jar app.jar extract
+# Ensure that the snapshot-dependencies folder is created even if there were no snapshot dependencies in the jar file (to avoid error when copying from that directory below)
+RUN mkdir -p snapshot-dependencies
 
 ## Stage 2 : create image
 FROM eclipse-temurin
 USER root
 WORKDIR /deployments
 COPY --from=builder /deployments/dependencies/ ./
+COPY --from=builder /deployments/snapshot-dependencies/ ./
 COPY --from=builder /deployments/spring-boot-loader/ ./
 COPY --from=builder /deployments/application/ ./
 COPY config ./config


### PR DESCRIPTION
Spring Boot's `extract` tool that the Dockerfiles use to extract files from the spring boot jar file handles snapshot and non-snapshot dependencies differently - which currently causes the snapshot dependencies to be missing from the created docker image. With this commit, the snapshot dependencies are also added to the created docker image.

Resolves #30